### PR TITLE
Create apple-developer.md

### DIFF
--- a/apple-developer.md
+++ b/apple-developer.md
@@ -1,0 +1,24 @@
+---
+layout: fr
+title: Apple Developer Program Membership
+author: vertion
+date: January, 24, 2022
+amount: 375
+milestones:
+- name: Apple Developer Program Membership (1 year)
+  funds: 375 VTC
+  done:
+  status: unfinished
+- date:
+  amount:
+---
+The last proposal for a code signing certificate [has been completed](https://ccs.vertcoin.io/proposals/code-signing-cert.html) and developers for Vertcoin now have a [code signing certificate!](https://github.com/vertcoin-project/vertcoin-core/pull/167)
+
+While this covers all binaries built for Windows, the next step is obtaining a code signing certificate from Apple.  This will ensure that binaries conform to the macOS "Gatekeeper" so as to minimise the warnings that users get and starting with macOS 10.15, binaries also need to be notarized by Apple's central server.
+
+I applied and our enrollment request to the Apple Developer Program has been accepted.  It requires a yearly membership fee of $99.
+
+I am doing final touch-ups on my rebase of Electrum and will soon to importing it to the vertcoin-project repository.  The first release will have code signed binaries for Windows and macOS along with a Linux AppImage.  I am excited for the release!
+___________
+
+**Apple Developer Program membership fee - $99 (375 VTC as of January 24, 2022)**


### PR DESCRIPTION
The last proposal for a code signing certificate [has been completed](https://ccs.vertcoin.io/proposals/code-signing-cert.html) and developers for Vertcoin now have a [code signing certificate!](https://github.com/vertcoin-project/vertcoin-core/pull/167)

While this covers all binaries built for Windows, the next step is obtaining a code signing certificate from Apple.  This will ensure that binaries conform to the macOS "Gatekeeper" so as to minimise the warnings that users get and starting with macOS 10.15, binaries also need to be notarized by Apple's central server.

I applied and our enrollment request to the Apple Developer Program has been accepted.  It requires a yearly membership fee of $99.

I am doing final touch-ups on my rebase of Electrum and will soon to importing it to the vertcoin-project repository.  The first release will have code signed binaries for Windows and macOS along with a Linux AppImage.  I am excited for the release!
___________

**Apple Developer Program membership fee - $99 (375 VTC as of January 24, 2022)**