### PR TITLE
Renew Codesigning Certificates 2023

### DIFF
--- a/code-signing-renewal-2023.md
+++ b/code-signing-renewal-2023.md
@@ -1,0 +1,32 @@
+---
+layout: fr
+title: Renew Codesigning Certificates 2023
+author: vertion
+date: December 22, 2022
+amount: 2300
+milestones:
+- name: Certificates renewed
+  funds: 2300 VTC
+  done: 
+  status: unfinished
+  payouts:
+- date: 
+  amount: 
+---
+
+# Proposal
+
+The Windows and macOS code signing certificates must be renewed yearly. These are currently used to sign Vertcoin-Core and Electrum but can be used for other Vertcoin related projects.
+
+___________
+The amounts required are as follows:
+
+**Comodo Code Signing Certificate - 1 Year $179**
+
+**Apple Developer Program - 1 Year $99**
+
+**Vertcoin Project Code Signing LLC registered agent - 1 year $49**
+
+___________
+
+**Total - $327 (2300 VTC as of December 22, 2022)**


### PR DESCRIPTION
# Proposal

The Windows and macOS code signing certificates must be renewed yearly. These are currently used to sign Vertcoin-Core and Electrum but can be used for other Vertcoin related projects.

___________
The amounts required are as follows:

**Comodo Code Signing Certificate - 1 Year $179**

**Apple Developer Program - 1 Year $99**

**Vertcoin Project Code Signing LLC registered agent - 1 year $49**

___________

**Total - $327 (2300 VTC as of December 22, 2022)**